### PR TITLE
Add up- and downvote tooltip

### DIFF
--- a/src/jsMain/kotlin/io/beatmaps/index/beatmapInfo.kt
+++ b/src/jsMain/kotlin/io/beatmaps/index/beatmapInfo.kt
@@ -57,6 +57,7 @@ class BeatmapInfo : RComponent<BeatmapInfoProps, RState>() {
                     }
                 }
                 div("percentage") {
+                    attrs.title = "${props.map.stats.upvotes}/${props.map.stats.downvotes}"
                     +"${(props.map.stats.score * 1000).toInt() / 10f}%"
                 }
             }


### PR DESCRIPTION
Shows the map's up- and downvotes when hovering over its rating.