### PR TITLE
Enforce https redirect

### DIFF
--- a/src/jvmMain/kotlin/io/beatmaps/server.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/server.kt
@@ -40,6 +40,7 @@ import io.ktor.features.DataConversion
 import io.ktor.features.NotFoundException
 import io.ktor.features.ParameterConversionException
 import io.ktor.features.StatusPages
+import io.ktor.features.HttpsRedirect
 import io.ktor.features.XForwardedHeaderSupport
 import io.ktor.html.respondHtmlTemplate
 import io.ktor.http.ContentType
@@ -152,6 +153,7 @@ fun Application.beatmapsio() {
         }
     }
 
+    install(HttpsRedirect)
     install(XForwardedHeaderSupport)
 
     install(ConditionalHeaders) {


### PR DESCRIPTION
At the moment http://beatsaver.com serves an website without TLS, instead it should return a redirect to https.
This PR aims to fix that by enforcing an https redirect via the KTor "HttpsRedirect" feature.