### PR TITLE
Add song length and BPM to map detail page

### DIFF
--- a/src/jsMain/kotlin/io/beatmaps/maps/infotable.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/infotable.kt
@@ -3,6 +3,7 @@ package io.beatmaps.maps
 import external.TimeAgo
 import io.beatmaps.api.MapDetail
 import io.beatmaps.api.MapDifficulty
+import io.beatmaps.common.formatTime
 import kotlinx.html.DIV
 import kotlinx.html.js.onClickFunction
 import kotlinx.html.role
@@ -93,6 +94,11 @@ class InfoTable : RComponent<InfoTableProps, RState>() {
                         }
                     }
                 }
+            }
+
+            props.map.metadata.let { metadata ->
+                infoItem("Song Length", metadata.duration.formatTime())
+                infoItem("BPM", "${metadata.bpm}")
             }
 
             props.map.stats.let { stats ->


### PR DESCRIPTION
https://github.com/beatmaps-io/beatsaver-main/issues/69. Nice.

![The details](https://user-images.githubusercontent.com/68104413/160240369-d76bdb57-c2d1-4cc4-828d-3396faf1c3b7.png)