### PR TITLE
Change downvote color to gold

### DIFF
--- a/src/jvmMain/sass/main.scss
+++ b/src/jvmMain/sass/main.scss
@@ -195,7 +195,7 @@ table.search-results {
         background: $green;
       }
       .d {
-        background: $red;
+        background: #222;
       }
       .o {
         background: $gray-700;

--- a/src/jvmMain/sass/main.scss
+++ b/src/jvmMain/sass/main.scss
@@ -195,7 +195,7 @@ table.search-results {
         background: $green;
       }
       .d {
-        background: #222;
+        background: $warning;
       }
       .o {
         background: $gray-700;


### PR DESCRIPTION
Suggestion: #112 

Back to original black proposal again (but a little lighter `#222`) since having a 10% map being brighter than a 50% no vote map is odd.
![Oooh another image :D](https://user-images.githubusercontent.com/68104413/168471460-83f8761d-3bd1-4bc4-ab2d-dccd8bd8e8e4.png)

New gold color:
![image](https://user-images.githubusercontent.com/68104413/176875158-abbdd71a-72d0-4daf-a3c1-9539d0f51fa3.png)
