### PR TITLE
Automatically flag bot maps

### DIFF
--- a/src/commonMain/kotlin/io/beatmaps/api/maps.kt
+++ b/src/commonMain/kotlin/io/beatmaps/api/maps.kt
@@ -33,6 +33,7 @@ data class MapDetail(
     val stats: MapStats,
     val uploaded: Instant? = null,
     val automapper: Boolean,
+    val ai: Boolean,
     val ranked: Boolean,
     val qualified: Boolean,
     val versions: List<MapVersion> = listOf(),

--- a/src/commonMain/kotlin/io/beatmaps/api/testplay.kt
+++ b/src/commonMain/kotlin/io/beatmaps/api/testplay.kt
@@ -8,5 +8,6 @@ import kotlinx.serialization.Serializable
 @Serializable data class MapInfoUpdate(val id: Int, val name: String? = null, val description: String? = null, val tags: List<String>? = null, val deleted: Boolean = false, val reason: String? = null)
 @Serializable data class CurateMap(val id: Int, val curated: Boolean = false)
 @Serializable data class ValidateMap(val id: Int, val automapper: Boolean = false)
+@Serializable data class DeclareMapAI(val id: Int, val ai: Boolean = false)
 @Serializable data class StateUpdate(val hash: String, val state: EMapState, val mapId: Int, val reason: String? = null, val scheduleAt: Instant? = null)
 @Serializable data class FeedbackUpdate(val hash: String, val feedback: String, val captcha: String? = null)

--- a/src/commonMain/resources/db/migration/V22_UnsureToBot.sql
+++ b/src/commonMain/resources/db/migration/V22_UnsureToBot.sql
@@ -1,0 +1,8 @@
+UPDATE beatmap
+    SET automapper = TRUE
+    FROM
+        beatmap AS b LEFT JOIN versions AS v ON b."mapId" = v."mapId"
+    WHERE
+        b."mapId" = beatmap."mapId"
+        AND state = 'Published'
+        AND "sageScore" < 0;

--- a/src/commonMain/resources/db/migration/V22_UnsureToBot.sql
+++ b/src/commonMain/resources/db/migration/V22_UnsureToBot.sql
@@ -1,8 +1,0 @@
-UPDATE beatmap
-    SET automapper = TRUE
-    FROM
-        beatmap AS b LEFT JOIN versions AS v ON b."mapId" = v."mapId"
-    WHERE
-        b."mapId" = beatmap."mapId"
-        AND state = 'Published'
-        AND "sageScore" < 0;

--- a/src/commonMain/resources/db/migration/V23__UnsureToBot.sql
+++ b/src/commonMain/resources/db/migration/V23__UnsureToBot.sql
@@ -1,0 +1,8 @@
+UPDATE beatmap
+    SET automapper = TRUE
+    FROM
+        beatmap AS b LEFT JOIN versions AS v ON b."mapId" = v."mapId"
+    WHERE
+        b."mapId" = beatmap."mapId"
+        AND state = 'Published'
+        AND "sageScore" < 0;

--- a/src/jsMain/kotlin/io/beatmaps/index/sharedMapComponents.kt
+++ b/src/jsMain/kotlin/io/beatmaps/index/sharedMapComponents.kt
@@ -35,10 +35,8 @@ val botInfo = functionComponent<BotInfoProps> { props ->
             +text
         }
 
-    if (score < -4 || props.automapper == true) {
+    if (score < 0 && props.automapper != false) {
         renderBadge("danger", "Made by a bot", "Bot")
-    } else if (score < 0) {
-        renderBadge("unsure", "Could be a bot", "Unsure")
     }
 }
 

--- a/src/jsMain/kotlin/io/beatmaps/index/sharedMapComponents.kt
+++ b/src/jsMain/kotlin/io/beatmaps/index/sharedMapComponents.kt
@@ -26,7 +26,6 @@ external interface BotInfoProps : RProps {
 }
 
 val botInfo = functionComponent<BotInfoProps> { props ->
-    val score = (props.version?.sageScore ?: 0)
     val margin = if (props.marginLeft != false) "ms-2" else "me-2"
 
     fun renderBadge(color: String, title: String, text: String) =
@@ -35,7 +34,7 @@ val botInfo = functionComponent<BotInfoProps> { props ->
             +text
         }
 
-    if (score < 0 && props.automapper != false) {
+    if (props.automapper != false) {
         renderBadge("danger", "Made by a bot", "Bot")
     }
 }

--- a/src/jsMain/kotlin/io/beatmaps/maps/infotable.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/infotable.kt
@@ -59,10 +59,6 @@ class InfoTable : RComponent<InfoTableProps, RState>() {
             }
 
             infoItem("Mapper", "${props.map.uploader.name} (${props.map.metadata.levelAuthorName})", "/profile/${props.map.uploader.id}")
-            val score = publishedVersion?.sageScore ?: 0
-            if (score < -4 || props.map.automapper) {
-                infoItem("AI", if (score < -4) "Bot" else "Unsure")
-            }
 
             div(itemClasses) {
                 +"Uploaded"

--- a/src/jsMain/kotlin/io/beatmaps/maps/mapinfo.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/mapinfo.kt
@@ -3,6 +3,7 @@ package io.beatmaps.maps
 import external.Axios
 import external.generateConfig
 import io.beatmaps.api.CurateMap
+import io.beatmaps.api.DeclareMapAI
 import io.beatmaps.api.MapDetail
 import io.beatmaps.api.MapInfoUpdate
 import io.beatmaps.api.SimpleMapInfoUpdate
@@ -37,6 +38,7 @@ import react.createRef
 import react.dom.InnerHTML
 import react.dom.RDOMBuilder
 import react.dom.a
+import react.dom.button
 import react.dom.div
 import react.dom.h4
 import react.dom.i
@@ -131,9 +133,31 @@ class MapInfo : RComponent<MapInfoProps, MapInfoState>() {
         }) { }
     }
 
+    private fun declareAI(ai: Boolean = true) {
+        Axios.post<String>("${Config.apibase}/maps/declareai", DeclareMapAI(props.mapInfo.intId(), ai), generateConfig<DeclareMapAI, String>()).then({
+            props.reloadMap()
+        }) { }
+    }
+
     override fun RBuilder.render() {
         val deleted = props.mapInfo.deletedAt != null
         globalContext.Consumer { userData ->
+            if (props.mapInfo.let { it.automapper && !it.ai && userData?.userId == it.uploader.id }) {
+                div("alert alert-danger alert-dismissible") {
+                    +"This map was automatically flagged as an AI-generated map. If you believe this was a mistake, please report it in the "
+                    a("https://discord.gg/rjVDapkMmj", classes = "alert-link") {
+                        +"BeatSaver Discord server"
+                    }
+                    +"."
+                    button(classes = "btn-close") {
+                        attrs.onClickFunction = {
+                            it.preventDefault()
+                            declareAI()
+                        }
+                    }
+                }
+            }
+
             div("card") {
                 div("card-header d-flex" + if (deleted) " bg-danger" else "") {
                     if (state.editing == true) {

--- a/src/jvmMain/kotlin/io/beatmaps/api/data.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/api/data.kt
@@ -23,7 +23,7 @@ fun cdnBase(prefix: String) = when (remoteCdn) {
 
 fun MapDetail.Companion.from(other: BeatmapDao, cdnPrefix: String) = MapDetail(
     toHexString(other.id.value), other.name, other.description,
-    UserDetail.from(other.uploader), MapDetailMetadata.from(other), MapStats.from(other), other.uploaded?.toKotlinInstant(), other.automapper, other.ranked, other.qualified,
+    UserDetail.from(other.uploader), MapDetailMetadata.from(other), MapStats.from(other), other.uploaded?.toKotlinInstant(), other.automapper, other.ai, other.ranked, other.qualified,
     other.versions.values.map { MapVersion.from(it, cdnPrefix) }.partition { it.state == EMapState.Published }.let {
         // Once a map is published hide previous versions
         it.first.ifEmpty {

--- a/src/jvmMain/kotlin/io/beatmaps/controllers/upload.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/controllers/upload.kt
@@ -271,7 +271,7 @@ fun Route.uploadController() {
                         setBasicMapInfo({ a, b -> it[a] = b }, { a, b -> it[a] = b }, { a, b -> it[a] = b })
 
                         val declaredAsAI = (multipart.dataMap["beatsage"] ?: "").isNotEmpty()
-                        it[automapper] = declaredAsAI || extractedInfo.score < -4
+                        it[automapper] = declaredAsAI || extractedInfo.score < 0
                         it[ai] = declaredAsAI
 
                         it[plays] = 0

--- a/src/jvmMain/kotlin/io/beatmaps/util/versions.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/util/versions.kt
@@ -74,7 +74,7 @@ fun publishVersion(mapId: Int, hash: String, additionalCallback: (Op<Boolean>) -
 
                 // Because of magical typing reasons this can't be one line
                 // They actually call completely different setting functions
-                if (originalState.sageScore != null && originalState.sageScore < -4) {
+                if (originalState.sageScore != null && originalState.sageScore < 0) {
                     it[automapper] = true
                 } else {
                     it[automapper] = ai

--- a/src/jvmMain/sass/main.scss
+++ b/src/jvmMain/sass/main.scss
@@ -17,7 +17,6 @@ $bs-blue: #1268a1;
 $bs-green: #008055;
 $bs-red: #b52a1c;
 $bs-orange: #bd5500;
-$bs-yellow: #fff301;
 $bs-purple: #454088;
 
 // Bring back old look
@@ -48,8 +47,7 @@ $theme-colors: (
   "green": $bs-green,
   "expert": $bs-red,
   "purple": $bs-purple,
-  "hard": $bs-orange,
-  "unsure": $bs-yellow
+  "hard": $bs-orange
 );
 
 @use "datepicker";


### PR DESCRIPTION
Removes the Unsure tag, and instead flags maps that trigger the AI filters as Bot maps automatically. If the uploader didn't indicate that the map was AI-assisted, a message will appear on the map page, explaining that the user can request their map to be looked at and revalidated.