### PR TITLE
Add improved alerts indicator

### DIFF
--- a/src/jvmMain/kotlin/io/beatmaps/controllers/policy.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/controllers/policy.kt
@@ -23,21 +23,21 @@ import io.ktor.sessions.sessions
 fun Route.policyController() {
     get<PolicyController.DMCA> {
         val sess = call.sessions.get<Session>()
-        call.respondHtmlTemplate(MainTemplate(sess, DMCAPageTemplate()), HttpStatusCode.OK) {
+        call.respondHtmlTemplate(MainTemplate(sess, true, DMCAPageTemplate()), HttpStatusCode.OK) {
             pageTitle = "BeatSaver - DMCA Policy"
         }
     }
 
     get<PolicyController.TOS> {
         val sess = call.sessions.get<Session>()
-        call.respondHtmlTemplate(MainTemplate(sess, TOSPageTemplate()), HttpStatusCode.OK) {
+        call.respondHtmlTemplate(MainTemplate(sess, true, TOSPageTemplate()), HttpStatusCode.OK) {
             pageTitle = "BeatSaver - Terms of Service"
         }
     }
 
     get<PolicyController.Privacy> {
         val sess = call.sessions.get<Session>()
-        call.respondHtmlTemplate(MainTemplate(sess, PrivacyPageTemplate()), HttpStatusCode.OK) {
+        call.respondHtmlTemplate(MainTemplate(sess, true, PrivacyPageTemplate()), HttpStatusCode.OK) {
             pageTitle = "BeatSaver - Privacy Policy"
         }
     }

--- a/src/jvmMain/kotlin/io/beatmaps/pages/templates/HeaderTemplate.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/pages/templates/HeaderTemplate.kt
@@ -8,15 +8,17 @@ import kotlinx.html.FlowContent
 import kotlinx.html.a
 import kotlinx.html.button
 import kotlinx.html.div
+import kotlinx.html.i
 import kotlinx.html.id
 import kotlinx.html.img
 import kotlinx.html.li
 import kotlinx.html.nav
+import kotlinx.html.small
 import kotlinx.html.span
 import kotlinx.html.title
 import kotlinx.html.ul
 
-class HeaderTemplate(private val s: Session?) : Template<FlowContent> {
+class HeaderTemplate(private val s: Session?, private val showAlerts: Boolean) : Template<FlowContent> {
     override fun FlowContent.apply() {
         nav("navbar navbar-expand-lg fixed-top navbar-dark bg-primary") {
             div("container") {
@@ -106,6 +108,16 @@ class HeaderTemplate(private val s: Session?) : Template<FlowContent> {
                             }
                         } else {
                             li("nav-item") {
+                                a("/profile#alerts", classes = "nav-link") {
+                                    i("fas fa-bell")
+                                    if (s.alerts != null && s.alerts > 0 && showAlerts) {
+                                        small("alert-count") {
+                                            if (s.alerts < 10) +s.alerts.toString() else +"9+"
+                                        }
+                                    }
+                                }
+                            }
+                            li("nav-item") {
                                 a("/upload", classes = "nav-link") {
                                     +"Upload"
                                 }
@@ -117,15 +129,6 @@ class HeaderTemplate(private val s: Session?) : Template<FlowContent> {
                                 div("dropdown-menu") {
                                     a("/profile", classes = "dropdown-item") {
                                         +"Profile"
-                                    }
-                                    a("/profile#alerts", classes = "dropdown-item") {
-                                        +"Alerts"
-
-                                        if (s.alerts != null && s.alerts > 0) {
-                                            span("ms-1 text-danger") {
-                                                +"•"
-                                            }
-                                        }
                                     }
                                     if (s.steamId == null) {
                                         a("/steam", classes = "dropdown-item") {

--- a/src/jvmMain/kotlin/io/beatmaps/pages/templates/MainTemplate.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/pages/templates/MainTemplate.kt
@@ -16,7 +16,7 @@ import kotlinx.html.meta
 import kotlinx.html.styleLink
 import kotlinx.html.title
 
-class MainTemplate(private val s: Session?, private val body: Template<BODY>) : Template<HTML> {
+class MainTemplate(private val s: Session?, private val showAlerts: Boolean, private val body: Template<BODY>) : Template<HTML> {
     private val header = TemplatePlaceholder<HeaderTemplate>()
     private val bodyPlaceholder = TemplatePlaceholder<Template<BODY>>()
     val headElements = Placeholder<HEAD>()
@@ -45,7 +45,7 @@ class MainTemplate(private val s: Session?, private val body: Template<BODY>) : 
             insert(headElements)
         }
         body {
-            insert(HeaderTemplate(s), header)
+            insert(HeaderTemplate(s, showAlerts), header)
             insert(body, bodyPlaceholder)
         }
     }

--- a/src/jvmMain/kotlin/io/beatmaps/server.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/server.kt
@@ -93,7 +93,7 @@ suspend fun PipelineContext<*, ApplicationCall>.genericPage(statusCode: HttpStat
     if (sess != null && sess.uniqueName == null && call.request.path() != "/username") {
         call.respondRedirect("/username")
     } else {
-        call.respondHtmlTemplate(MainTemplate(sess, GenericPageTemplate(sess)), statusCode) {
+        call.respondHtmlTemplate(MainTemplate(sess, call.request.path() != "/profile", GenericPageTemplate(sess)), statusCode) {
             headElements {
                 headerTemplate?.invoke(this)
             }

--- a/src/jvmMain/sass/main.scss
+++ b/src/jvmMain/sass/main.scss
@@ -1027,6 +1027,17 @@ table.modlog {
   }
 }
 
+small.alert-count {
+  font-size: 10px;
+  text-align: center;
+  display: inline-block;
+  line-height: 13px;
+  min-width: 13px;
+  margin: 0 -7.5px;
+  border-radius: 50%;
+  background-color: $danger;
+}
+
 @include media-breakpoint-up(sm) {
   .filter-dropdown {
     width: 100%;


### PR DESCRIPTION
Known issue: Due to caching (presumably), alert count can display incorrectly when moving between pages. Refreshing fixes this.