### PR TITLE
Add GitHub to social link parser

### DIFF
--- a/src/jsMain/kotlin/io/beatmaps/util/markdown.kt
+++ b/src/jsMain/kotlin/io/beatmaps/util/markdown.kt
@@ -37,6 +37,7 @@ fun String.parseSocialLinks() =
         "(^|\\s)steam@(\\d+?)($|\\W)" to """$1<a href="https://steamcommunity.com/profiles/$2">steam@$2</a>$3""",
         "(^|\\s)ss@(\\d+?)($|\\W)" to """$1<a href="https://scoresaber.com/u/$2">ss@$2</a>$3""",
         "(^|\\s)bl@(\\d+?)($|\\W)" to """$1<a href="https://www.beatleader.xyz/u/$2">bl@$2</a>$3""",
+        "(^|\\s)gh@(\\w+?)($|\\W)" to """$1<a href="https://www.github.com/$2">gh@$2</a>$3""",
     ).fold(this) { v, it ->
         v.replace(it.first.toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE)), it.second)
     }

--- a/src/jsMain/kotlin/io/beatmaps/util/markdown.kt
+++ b/src/jsMain/kotlin/io/beatmaps/util/markdown.kt
@@ -37,7 +37,7 @@ fun String.parseSocialLinks() =
         "(^|\\s)steam@(\\d+?)($|\\W)" to """$1<a href="https://steamcommunity.com/profiles/$2">steam@$2</a>$3""",
         "(^|\\s)ss@(\\d+?)($|\\W)" to """$1<a href="https://scoresaber.com/u/$2">ss@$2</a>$3""",
         "(^|\\s)bl@(\\d+?)($|\\W)" to """$1<a href="https://www.beatleader.xyz/u/$2">bl@$2</a>$3""",
-        "(^|\\s)gh@(\\w+?)($|\\W)" to """$1<a href="https://www.github.com/$2">gh@$2</a>$3""",
+        "(^|\\s)gh@([\\w.-]+?)($|[^\\w.-])" to """$1<a href="https://www.github.com/$2">gh@$2</a>$3""",
     ).fold(this) { v, it ->
         v.replace(it.first.toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE)), it.second)
     }


### PR DESCRIPTION
clearly GitHub is a very important social platform that demands beatsaver bio support. This PR (attempts to) map `gh@<username>` to `https://github.com/<username>`

I will be completely transparent: This was done with the github online text editor lmao