### PR TITLE
Use docker volumes instead of local filesystem bind mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./db:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: beatmaps
       POSTGRES_USER: beatmaps
@@ -16,7 +16,7 @@ services:
     ports:
       - "27017:27017"
     volumes:
-      - ./mongo:/data/db
+      - mongo_data:/data/db
       - ./src/commonMain/resources/mongo:/docker-entrypoint-initdb.d:ro
     environment:
       MONGO_INITDB_ROOT_USERNAME: "root"
@@ -25,3 +25,6 @@ services:
       MONGO_USER: "beatmaps"
       MONGO_PASSWORD: "insecure-password"
     restart: always
+volumes:
+  db_data:
+  mongo_data:


### PR DESCRIPTION
This PR addresses an issue reported in the Discord. When using Windows Subsystem for Linux, local directories being used for file-systems mounted to the docker container will have permission problems.

This change is not backwards compatible, but should be worth the change since the DB is rebuilt easily. In the related Docker Volume documentation, the backup/restore can be used if data is still important for individuals.

Related Resources:

* [Docker Compose Volumes](https://docs.docker.com/compose/compose-file/07-volumes/)
* [Docker Volumes](https://docs.docker.com/storage/volumes/)