### PR TITLE
Use human tag names when showing the selected tags in general search

### DIFF
--- a/src/jsMain/kotlin/io/beatmaps/shared/search/search.kt
+++ b/src/jsMain/kotlin/io/beatmaps/shared/search/search.kt
@@ -5,7 +5,6 @@ import external.Moment
 import io.beatmaps.common.MapTag
 import io.beatmaps.common.SearchOrder
 import io.beatmaps.common.SortOrderTarget
-import io.beatmaps.maps.mapTag
 import io.beatmaps.shared.form.slider
 import io.beatmaps.shared.form.toggle
 import kotlinx.browser.document

--- a/src/jsMain/kotlin/io/beatmaps/shared/search/search.kt
+++ b/src/jsMain/kotlin/io/beatmaps/shared/search/search.kt
@@ -198,7 +198,7 @@ open class Search<T : CommonParams>(props: SearchProps<T>) : RComponent<SearchPr
                                     if (it.startsWith("!")) {
                                         "!" + MapTag.fromSlug(it.removePrefix("!"))
                                     } else {
-                                        MapTag.fromSlug(it)
+                                        MapTag.fromSlug(it) ?: it
                                     }
                                 }.joinToString(", ")
                             }

--- a/src/jsMain/kotlin/io/beatmaps/shared/search/search.kt
+++ b/src/jsMain/kotlin/io/beatmaps/shared/search/search.kt
@@ -2,8 +2,10 @@ package io.beatmaps.shared.search
 
 import external.DateRangePicker
 import external.Moment
+import io.beatmaps.common.MapTag
 import io.beatmaps.common.SearchOrder
 import io.beatmaps.common.SortOrderTarget
+import io.beatmaps.maps.mapTag
 import io.beatmaps.shared.form.slider
 import io.beatmaps.shared.form.toggle
 import kotlinx.browser.document
@@ -192,7 +194,13 @@ open class Search<T : CommonParams>(props: SearchProps<T>) : RComponent<SearchPr
                             if (filters.isEmpty()) {
                                 +"Filters"
                             } else {
-                                +filters.joinToString(", ")
+                                +filters.map {
+                                    if (it.startsWith("!")) {
+                                        "!" + MapTag.fromSlug(it.removePrefix("!"))
+                                    } else {
+                                        MapTag.fromSlug(it)
+                                    }
+                                }.joinToString(", ")
                             }
                         }
                         i("fas fa-angle-" + if (state.filtersOpen == true) "up" else "down") {}

--- a/src/jsMain/kotlin/io/beatmaps/shared/search/search.kt
+++ b/src/jsMain/kotlin/io/beatmaps/shared/search/search.kt
@@ -193,13 +193,13 @@ open class Search<T : CommonParams>(props: SearchProps<T>) : RComponent<SearchPr
                             if (filters.isEmpty()) {
                                 +"Filters"
                             } else {
-                                +filters.map {
+                                +filters.joinToString(", ") {
                                     if (it.startsWith("!")) {
                                         "!" + MapTag.fromSlug(it.removePrefix("!"))
                                     } else {
-                                        MapTag.fromSlug(it) ?: it
+                                        (MapTag.fromSlug(it) ?: it).toString()
                                     }
-                                }.joinToString(", ")
+                                }
                             }
                         }
                         i("fas fa-angle-" + if (state.filtersOpen == true) "up" else "down") {}


### PR DESCRIPTION
This PR will switch the filters for tags to use human labels instead of the key.

![image](https://github.com/beatmaps-io/beatsaver-main/assets/519553/9c7f12a2-e99f-4882-b170-3f542bfe686b)

I'm not a fan of this solution. I think the filters should have an interface that defines whether the filter is "inverse", and has the human and key on it. Then the code could be reduced to:

```kotlin
filters.map { it.humanFormatted }.joinToString(", ")
```

I've been having a hard time figuring out how the `!` ends up in the output, and how I could generalize the filters and tags.