### PR TITLE
Review opt-out

### DIFF
--- a/src/commonMain/kotlin/io/beatmaps/api/users.kt
+++ b/src/commonMain/kotlin/io/beatmaps/api/users.kt
@@ -39,7 +39,8 @@ data class UserDetail(
     val verifiedMapper: Boolean = false,
     val suspendedAt: Instant? = null,
     val playlistUrl: String? = null,
-    val patreon: PatreonTier? = null
+    val patreon: PatreonTier? = null,
+    val reviewsEnabled: Boolean = true
 ) {
     fun profileLink(tab: String? = null, absolute: Boolean = false) = UserDetailHelper.profileLink(this, tab, absolute)
     companion object
@@ -76,6 +77,9 @@ data class UserDiffStats(val total: Int, val easy: Int, val normal: Int, val har
 
 @Serializable
 data class AccountDetailReq(val textContent: String)
+
+@Serializable
+data class ReviewOptRequest(val enableReviews: Boolean)
 
 @Serializable
 data class RegisterRequest(val captcha: String, val username: String, val email: String, val password: String, val password2: String)

--- a/src/commonMain/resources/db/migration/V65__ReviewOptOut.sql
+++ b/src/commonMain/resources/db/migration/V65__ReviewOptOut.sql
@@ -1,0 +1,2 @@
+ALTER TABLE uploader
+    ADD "reviewsEnabled" bool not null default true;

--- a/src/jsMain/kotlin/io/beatmaps/maps/infotable.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/infotable.kt
@@ -158,7 +158,7 @@ val infoTable = fc<InfoTableProps> { props ->
         props.map.stats.let { stats ->
             infoItem("Rating", "${stats.upvotes} / ${stats.downvotes} (${stats.scoreOneDP}%)")
 
-            if (ReviewConstants.COMMENTS_ENABLED) {
+            if (ReviewConstants.COMMENTS_ENABLED && props.map.uploader.reviewsEnabled) {
                 div(itemClasses) {
                     +"Reviews"
                     span("text-truncate ms-4") {

--- a/src/jsMain/kotlin/io/beatmaps/maps/main.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/main.kt
@@ -138,7 +138,7 @@ val mapPage = fc<MapPageProps> { props ->
                     if (showComments) {
                         reviewTable {
                             attrs.map = it.id
-                            attrs.mapUploaderId = it.uploader.id
+                            attrs.uploader = it.uploader
                         }
                     } else if (version != null && it.deletedAt == null) {
                         scoreTable {

--- a/src/jsMain/kotlin/io/beatmaps/shared/review/main.kt
+++ b/src/jsMain/kotlin/io/beatmaps/shared/review/main.kt
@@ -15,6 +15,7 @@ import io.beatmaps.util.useDidUpdateEffect
 import org.w3c.dom.HTMLElement
 import react.Props
 import react.dom.div
+import react.dom.p
 import react.fc
 import react.useContext
 import react.useRef
@@ -22,7 +23,7 @@ import react.useState
 
 external interface ReviewTableProps : Props {
     var map: String?
-    var mapUploaderId: Int?
+    var uploader: UserDetail?
     var userDetail: UserDetail?
     var fullWidth: Boolean?
 }
@@ -53,13 +54,22 @@ val reviewTable = fc<ReviewTableProps> { props ->
         }
     }
 
+    if (props.uploader?.reviewsEnabled == false) {
+        div(if (props.fullWidth == true) "" else " col-lg-8") {
+            p("text-danger-light text-center p-3") {
+                +"The uploader of this map has opted out of receiving reviews."
+            }
+        }
+        return@fc
+    }
+
     div("reviews" + if (props.fullWidth == true) "" else " col-lg-8") {
         ref = resultsTable
         key = "resultsTable"
 
         globalContext.Consumer { userData ->
             props.map?.let { map ->
-                if (userData != null && !userData.suspended && userData.userId != props.mapUploaderId) {
+                if (userData != null && !userData.suspended && userData.userId != props.uploader?.id) {
                     newReview {
                         attrs.mapId = map
                         attrs.userId = userData.userId

--- a/src/jsMain/kotlin/io/beatmaps/user/account.kt
+++ b/src/jsMain/kotlin/io/beatmaps/user/account.kt
@@ -11,6 +11,7 @@ import io.beatmaps.Config
 import io.beatmaps.api.AccountDetailReq
 import io.beatmaps.api.AccountType
 import io.beatmaps.api.ActionResponse
+import io.beatmaps.api.ReviewOptRequest
 import io.beatmaps.api.SessionInfo
 import io.beatmaps.api.SessionRevokeRequest
 import io.beatmaps.api.SessionsData
@@ -42,6 +43,7 @@ import react.dom.h5
 import react.dom.hr
 import react.dom.input
 import react.dom.label
+import react.dom.span
 import react.fc
 import react.useEffect
 import react.useRef
@@ -59,6 +61,8 @@ val accountTab = fc<AccountComponentProps> { props ->
     val (userLoading, setUserLoading) = useState(false)
 
     val (descriptionErrors, setDescriptionErrors) = useState(listOf<String>())
+
+    val (reviewOptErrors, setReviewOptErrors) = useState(listOf<String>())
 
     val (uploading, setUploading) = useState(false)
     val avatarRef = useRef<HTMLInputElement>()
@@ -187,6 +191,36 @@ val accountTab = fc<AccountComponentProps> { props ->
                         }
                     } else {
                         Promise.reject(IllegalStateException("Description unchanged"))
+                    }
+                }
+            }
+        }
+        errors {
+            attrs.errors = reviewOptErrors
+        }
+        div("mb-3") {
+            label("form-label me-3") {
+                attrs.reactFor = "reviews-enabled"
+                +"Reviews Enabled"
+            }
+            span("form-switch") {
+                input(InputType.checkBox, classes = "form-check-input") {
+                    attrs.id = "reviews-enabled"
+                    attrs.defaultChecked = props.userDetail.reviewsEnabled
+                    attrs.onChangeFunction = { ev ->
+                        Axios.post<ActionResponse>(
+                            "${Config.apibase}/users/reviews-opt",
+                            ReviewOptRequest((ev.target as HTMLInputElement).checked),
+                            generateConfig<ReviewOptRequest, ActionResponse>()
+                        ).then {
+                            if (it.data.success) {
+                                props.onUpdate()
+                            } else {
+                                setReviewOptErrors(it.data.errors)
+                            }
+
+                            it
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR will add a toggle to the user settings, allowing users to opt out of the reviews feature. This means no reviews can be left on any of the maps the user uploads, and existing reviews will be hidden. This setting can not be toggled on a map-by-map basis, it's all or nothing.

The current implementation does allow reviews on maps that have these users as collaborators, as long as the main uploader has reviews enabled. Whether or not this should the case would require further thought.

Some screenshots (don't mind the outdated UI elements):
![image](https://github.com/user-attachments/assets/a0a6c630-3320-4651-903b-607526668a45)
![image](https://github.com/user-attachments/assets/4161c03d-7dc3-4968-89db-c9e6896a3ae6)


Requires beatmaps-io/beatsaver-common-mp#43

There wasn't a clear consensus on whether or not people wanted this, but it's here if they do.