### PR TITLE
Rename Map Curation alerts to Followed Curations

### DIFF
--- a/src/jvmMain/kotlin/io/beatmaps/api/maps.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/api/maps.kt
@@ -236,7 +236,7 @@ fun Route.mapDetailRoute() {
                                     }
 
                                     Alert.insert(
-                                        "Map Curated",
+                                        "Followed Curation",
                                         "@${user.uniqueName} just curated #${toHexString(mapUpdate.id)}: **${it.name}**.\n" +
                                             "*\"${it.description.replace(Regex("\n+"), " ").take(100)}...\"*",
                                         EAlertType.MapCurated,


### PR DESCRIPTION
See also: beatmaps-io/beatsaver-common-mp#50

I could have changed the enum entry name in the database, but didn't deem it necessary. 
I also could have changed the titles of existing alerts, but idem. 

If you'd like me to do either, I will.