### PR TITLE
Fix link to Curators' curations tab from Map Card

### DIFF
--- a/src/jsMain/kotlin/io/beatmaps/maps/infotable.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/infotable.kt
@@ -129,7 +129,7 @@ val infoTable = fc<InfoTableProps> { props ->
         }
 
         props.map.curator?.let { curator ->
-            infoItem("Curated by", curator.name, curator.profileLink("curated"))
+            infoItem("Curated by", curator.name, curator.profileLink("curations"))
         }
 
         if (props.map.tags.isNotEmpty()) {


### PR DESCRIPTION
Should fix the link when clicking on a Curator's name from a Curated map card to go to their "curations" tab instead of "curated" as this URL doesn't exist.