### PR TITLE
Notifications for map updates (+ option to prevent notifications when publishing)

### DIFF
--- a/src/commonMain/kotlin/io/beatmaps/api/testplay.kt
+++ b/src/commonMain/kotlin/io/beatmaps/api/testplay.kt
@@ -13,6 +13,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable data class AiDeclaration(val id: Int, val automapper: Boolean = false)
 
-@Serializable data class StateUpdate(val hash: String, val state: EMapState, val mapId: Int, val reason: String? = null, val scheduleAt: Instant? = null)
+@Serializable data class StateUpdate(val hash: String, val state: EMapState, val mapId: Int, val reason: String? = null, val scheduleAt: Instant? = null, val alert: Boolean? = true)
 
 @Serializable data class FeedbackUpdate(val hash: String, val feedback: String, val captcha: String? = null)

--- a/src/jsMain/kotlin/io/beatmaps/maps/testplay/publishModal.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/testplay/publishModal.kt
@@ -22,11 +22,13 @@ import react.fc
 import react.useState
 
 external interface PublishModalProps : Props {
-    var callback: (Instant?) -> Unit
+    var callbackScheduleAt: (Instant?) -> Unit
+    var callbackAlert: (Boolean) -> Unit
 }
 
 val publishModal = fc<PublishModalProps> { props ->
     val (publishType, setPublishType) = useState(false)
+    val (alert, setAlert) = useState(true)
 
     val format = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm")
 
@@ -55,7 +57,7 @@ val publishModal = fc<PublishModalProps> { props ->
                     attrs.value = "now"
                     attrs.defaultChecked = true
                     attrs.onChangeFunction = {
-                        props.callback(null)
+                        props.callbackScheduleAt(null)
                         setPublishType(false)
                     }
                 }
@@ -84,11 +86,26 @@ val publishModal = fc<PublishModalProps> { props ->
                         attrs.min = nowStr
                         attrs.onChangeFunction = {
                             val textVal = (it.target as HTMLInputElement).value
-                            props.callback(if (textVal.isEmpty()) null else textVal.toInstant())
+                            props.callbackScheduleAt(if (textVal.isEmpty()) null else textVal.toInstant())
                         }
                     }
                 }
             }
+        }
+    }
+    div("form-check form-switch d-inline-block me-2") {
+        input(InputType.checkBox, classes = "form-check-input") {
+            attrs.checked = alert
+            attrs.id = "alertUpdate"
+            attrs.onChangeFunction = {
+                val boolVal = (it.currentTarget as HTMLInputElement).checked
+                setAlert(boolVal)
+                props.callbackAlert(boolVal)
+            }
+        }
+        label("form-check-label") {
+            attrs.reactFor = "alertUpdate"
+            +"Notify followers"
         }
     }
 }

--- a/src/jsMain/kotlin/io/beatmaps/maps/testplay/version.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/testplay/version.kt
@@ -55,6 +55,7 @@ val version = fc<VersionProps> { props ->
     val (time, setTime) = useState(props.time)
     val (scheduledAt, setScheduledAt) = useState(props.scheduledAt)
     val scheduleAt = useRef<Instant>(null)
+    val alert = useRef<Boolean>(true)
 
     val textareaRef = useRef<HTMLTextAreaElement>()
 
@@ -63,7 +64,7 @@ val version = fc<VersionProps> { props ->
     val mapState = { nextState: EMapState ->
         setLoadingState(true)
 
-        Axios.post<String>("${Config.apibase}/testplay/state", StateUpdate(props.hash, nextState, props.mapId, scheduleAt = scheduleAt.current), generateConfig<StateUpdate, String>()).then({
+        Axios.post<String>("${Config.apibase}/testplay/state", StateUpdate(props.hash, nextState, props.mapId, scheduleAt = scheduleAt.current, alert = alert.current), generateConfig<StateUpdate, String>()).then({
             if (nextState == EMapState.Published) {
                 if (scheduleAt.current == null) {
                     props.reloadMap()
@@ -123,8 +124,11 @@ val version = fc<VersionProps> { props ->
                                         ) {
                                             scheduleAt.current = null
                                             publishModal {
-                                                attrs.callback = {
+                                                attrs.callbackScheduleAt = {
                                                     scheduleAt.current = it
+                                                }
+                                                attrs.callbackAlert = {
+                                                    alert.current = it
                                                 }
                                             }
                                         }

--- a/src/jvmMain/kotlin/io/beatmaps/api/testplay.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/api/testplay.kt
@@ -214,7 +214,7 @@ fun Route.testplayRoute() {
                 )
 
                 if (newState.state == EMapState.Published) {
-                    publishVersion(newState.mapId, newState.hash, call.rb()) {
+                    publishVersion(newState.mapId, newState.hash, newState.alert, call.rb()) {
                         it and (Beatmap.uploader eq sess.userId)
                     }
                 } else {

--- a/src/jvmMain/kotlin/io/beatmaps/util/scheduled.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/util/scheduled.kt
@@ -30,7 +30,12 @@ class CheckScheduled(private val rb: RabbitMQInstance) : TimerTask() {
                 ).mapNotNull {
                     schedulerLogger.info { "Scheduler publishing ${it.hash}" }
                     runBlocking { delay(1L) }
-                    if (publishVersion(it.mapId.value, it.hash, rb)) it else null
+                    // Undeceiver: I am not adding the "alert" parameter to the database because it feels like too much effort for
+                    // the unlikely case that someone scheduled a map for release but doesn't want to notify followers,
+                    // If this ever happens, the alert will go out regardless (if it's scheduled it's likely it's a big deal).
+                    // If we did want to consider the parameter, it can be passed here without any problem,
+                    // but then we'd have to save it in the database when scheduling. Can be done, not doing it now.
+                    if (publishVersion(it.mapId.value, it.hash, true, rb)) it else null
                 }
             }.forEach {
                 rb.publish("beatmaps", "maps.${it.mapId.value}.updated.state", null, it.mapId.value)

--- a/src/jvmMain/kotlin/io/beatmaps/util/scheduled.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/util/scheduled.kt
@@ -30,11 +30,6 @@ class CheckScheduled(private val rb: RabbitMQInstance) : TimerTask() {
                 ).mapNotNull {
                     schedulerLogger.info { "Scheduler publishing ${it.hash}" }
                     runBlocking { delay(1L) }
-                    // Undeceiver: I am not adding the "alert" parameter to the database because it feels like too much effort for
-                    // the unlikely case that someone scheduled a map for release but doesn't want to notify followers,
-                    // If this ever happens, the alert will go out regardless (if it's scheduled it's likely it's a big deal).
-                    // If we did want to consider the parameter, it can be passed here without any problem,
-                    // but then we'd have to save it in the database when scheduling. Can be done, not doing it now.
                     if (publishVersion(it.mapId.value, it.hash, true, rb)) it else null
                 }
             }.forEach {

--- a/src/jvmMain/kotlin/io/beatmaps/util/versions.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/util/versions.kt
@@ -128,22 +128,13 @@ fun pushAlerts(map: BeatmapDao, rb: RabbitMQInstance?) {
         row[Follows.followerId].value
     }
 
-    if (map.lastPublishedAt == null) {
-        Alert.insert(
-            "New Map Release",
-            "@${map.uploader.uniqueName} just released #${toHexString(map.id.value)}: **${map.name}**.\n" +
-                "*\"${map.description.replace(Regex("\n+"), " ").take(100)}...\"*",
-            EAlertType.MapRelease,
-            recipients
-        )
-    } else {
-        Alert.insert(
-            "Map Updated",
-            "@${map.uploader.uniqueName} just updated #${toHexString(map.id.value)}: **${map.name}**.\n" +
-                "*\"${map.description.replace(Regex("\n+"), " ").take(100)}...\"*",
-            EAlertType.MapRelease,
-            recipients
-        )
-    }
+    val (title, adjective) = if (map.lastPublishedAt == null) ("New Map Release" to "released") else ("Map Updated" to "updated")
+    Alert.insert(
+        title,
+        "@${map.uploader.uniqueName} just $adjective #${toHexString(map.id.value)}: **${map.name}**.\n" +
+            "*\"${map.description.replace(Regex("\n+"), " ").take(100)}...\"*",
+        EAlertType.MapRelease,
+        recipients
+    )
     updateAlertCount(rb, recipients)
 }

--- a/src/jvmMain/kotlin/io/beatmaps/util/versions.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/util/versions.kt
@@ -31,7 +31,7 @@ import java.lang.Integer.toHexString
 import java.math.BigDecimal
 import java.time.Instant
 
-fun publishVersion(mapId: Int, hash: String, rb: RabbitMQInstance?, additionalCallback: (Op<Boolean>) -> Op<Boolean> = { it }): Boolean {
+fun publishVersion(mapId: Int, hash: String, alert: Boolean?, rb: RabbitMQInstance?, additionalCallback: (Op<Boolean>) -> Op<Boolean> = { it }): Boolean {
     val publishingVersion = VersionsDao.wrapRow(
         Versions.select {
             Versions.hash eq hash
@@ -73,11 +73,13 @@ fun publishVersion(mapId: Int, hash: String, rb: RabbitMQInstance?, additionalCa
         val map = Beatmap
             .joinUploader()
             .select {
-                (Beatmap.id eq mapId) and (Beatmap.lastPublishedAt.isNull())
+                (Beatmap.id eq mapId)
             }.firstOrNull()
             ?.let { BeatmapDao.wrapRow(it) }
             ?.also {
-                pushAlerts(it, rb)
+                if (alert == true) {
+                    pushAlerts(it, rb)
+                }
             }
 
         // Set published time for sorting, but don't allow gaming the system
@@ -126,12 +128,22 @@ fun pushAlerts(map: BeatmapDao, rb: RabbitMQInstance?) {
         row[Follows.followerId].value
     }
 
-    Alert.insert(
-        "New Map Release",
-        "@${map.uploader.uniqueName} just released #${toHexString(map.id.value)}: **${map.name}**.\n" +
-            "*\"${map.description.replace(Regex("\n+"), " ").take(100)}...\"*",
-        EAlertType.MapRelease,
-        recipients
-    )
+    if (map.lastPublishedAt == null) {
+        Alert.insert(
+            "New Map Release",
+            "@${map.uploader.uniqueName} just released #${toHexString(map.id.value)}: **${map.name}**.\n" +
+                "*\"${map.description.replace(Regex("\n+"), " ").take(100)}...\"*",
+            EAlertType.MapRelease,
+            recipients
+        )
+    } else {
+        Alert.insert(
+            "Map Updated",
+            "@${map.uploader.uniqueName} just updated #${toHexString(map.id.value)}: **${map.name}**.\n" +
+                "*\"${map.description.replace(Regex("\n+"), " ").take(100)}...\"*",
+            EAlertType.MapRelease,
+            recipients
+        )
+    }
     updateAlertCount(rb, recipients)
 }


### PR DESCRIPTION
(Different) notifications get sent to followers when updating a map (upon publishing a new version). But also, a new check input has been added to the Publish modal window (by default set to true) that allows the uploader to choose not to notify their followers (In case of very small updates, for example).

https://discord.com/channels/882730837974609940/1177359210233729044

![image](https://github.com/beatmaps-io/beatsaver-main/assets/22258580/466c93bf-f9e9-4c18-b6cc-1fed889ba204)

![image](https://github.com/beatmaps-io/beatsaver-main/assets/22258580/8e8ffd66-8ce7-4a00-ab79-339ed89d91c6)
