### PR TITLE
Fixes to recent alert features

### DIFF
--- a/src/jsMain/kotlin/io/beatmaps/maps/testplay/publishModal.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/testplay/publishModal.kt
@@ -24,6 +24,7 @@ import react.useState
 external interface PublishModalProps : Props {
     var callbackScheduleAt: (Instant?) -> Unit
     var callbackAlert: (Boolean) -> Unit
+    var notifyFollowersDefault: Boolean
 }
 
 val publishModal = fc<PublishModalProps> { props ->
@@ -94,7 +95,7 @@ val publishModal = fc<PublishModalProps> { props ->
     }
     div("form-check form-switch d-inline-block me-2") {
         input(InputType.checkBox, classes = "form-check-input") {
-            attrs.defaultChecked = true
+            attrs.defaultChecked = props.notifyFollowersDefault
             attrs.id = "alertUpdate"
             attrs.onChangeFunction = {
                 val boolVal = (it.currentTarget as HTMLInputElement).checked

--- a/src/jsMain/kotlin/io/beatmaps/maps/testplay/timeline.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/testplay/timeline.kt
@@ -142,6 +142,7 @@ val timeline = fc<TimelineProps> { props ->
                         attrs.reloadMap = props.reloadMap
                         attrs.mapId = props.mapInfo.intId()
                         attrs.allowPublish = props.mapInfo.name.isNotEmpty()
+                        attrs.alreadyPublished = (props.mapInfo.lastPublishedAt != null)
                     }
                     first = false
                 }

--- a/src/jsMain/kotlin/io/beatmaps/maps/testplay/version.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/testplay/version.kt
@@ -44,6 +44,7 @@ external interface VersionProps : Props {
     var scheduledAt: Instant?
     var reloadMap: () -> Unit
     var allowPublish: Boolean?
+    var alreadyPublished: Boolean?
 }
 private const val testplayEnabled = false
 
@@ -130,6 +131,7 @@ val version = fc<VersionProps> { props ->
                                                 attrs.callbackAlert = {
                                                     alert.current = it
                                                 }
+                                                attrs.notifyFollowersDefault = (props.alreadyPublished != true)
                                             }
                                         }
                                     )

--- a/src/jvmMain/kotlin/io/beatmaps/api/collaboration.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/api/collaboration.kt
@@ -130,7 +130,7 @@ fun Route.collaborationRoute() {
                                 .select(Follows.followerId)
                                 .where {
                                     followsAlias[Follows.id].isNull() and (Follows.followerId neq map.uploaderId) and
-                                            (Follows.userId eq sess.userId) and Follows.collab and Follows.following
+                                        (Follows.userId eq sess.userId) and Follows.collab and Follows.following
                                 }
                                 .map { row ->
                                     row[Follows.followerId].value
@@ -143,7 +143,7 @@ fun Route.collaborationRoute() {
                                         map.id.value
                                     )
                                 }: **${map.name}**.\n" +
-                                        "*\"${map.description.replace(Regex("\n+"), " ").take(100)}...\"*",
+                                    "*\"${map.description.replace(Regex("\n+"), " ").take(100)}...\"*",
                                 EAlertType.MapRelease,
                                 recipients
                             )

--- a/src/jvmMain/kotlin/io/beatmaps/api/users.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/api/users.kt
@@ -39,6 +39,7 @@ import io.beatmaps.common.dbo.UserLog
 import io.beatmaps.common.dbo.Versions
 import io.beatmaps.common.dbo.complexToBeatmap
 import io.beatmaps.common.dbo.handlePatreon
+import io.beatmaps.common.dbo.joinCollaborations
 import io.beatmaps.common.dbo.joinPatreon
 import io.beatmaps.common.dbo.joinVersions
 import io.beatmaps.common.sendEmail
@@ -1034,7 +1035,7 @@ fun Route.userRoute() {
     get<UsersApi.UserPlaylist> {
         val (maps, user) = transaction {
             Beatmap.joinVersions()
-                .join(Collaboration, JoinType.LEFT, onColumn = Beatmap.id, otherColumn = Collaboration.mapId)
+                .joinCollaborations()
                 .selectAll().where {
                     ((Beatmap.uploader eq it.id) or (Collaboration.collaboratorId eq it.id)) and Beatmap.deletedAt.isNull()
                 }.complexToBeatmap().sortedByDescending { b -> b.uploaded } to User.selectAll().where { User.id eq it.id and User.active }.firstOrNull()?.let { row -> UserDetail.from(row) }

--- a/src/jvmMain/kotlin/io/beatmaps/util/versions.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/util/versions.kt
@@ -17,6 +17,8 @@ import io.beatmaps.common.dbo.DifficultyDao
 import io.beatmaps.common.dbo.Follows
 import io.beatmaps.common.dbo.Versions
 import io.beatmaps.common.dbo.VersionsDao
+import io.beatmaps.common.dbo.complexToBeatmap
+import io.beatmaps.common.dbo.joinCollaborators
 import io.beatmaps.common.dbo.joinUploader
 import org.jetbrains.exposed.sql.Expression
 import org.jetbrains.exposed.sql.JoinType
@@ -25,6 +27,7 @@ import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.QueryParameter
 import org.jetbrains.exposed.sql.SqlExpressionBuilder
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import pl.jutupe.ktor_rabbitmq.RabbitMQInstance
@@ -74,11 +77,12 @@ fun publishVersion(mapId: Int, hash: String, alert: Boolean?, rb: RabbitMQInstan
 
         val map = Beatmap
             .joinUploader()
+            .joinCollaborators()
             .selectAll()
             .where {
                 (Beatmap.id eq mapId)
-            }.firstOrNull()
-            ?.let { BeatmapDao.wrapRow(it) }
+            }.complexToBeatmap()
+            .firstOrNull()
             ?.also {
                 if (alert == true) {
                     pushAlerts(it, rb)
@@ -125,16 +129,23 @@ fun publishVersion(mapId: Int, hash: String, alert: Boolean?, rb: RabbitMQInstan
 }
 
 fun pushAlerts(map: BeatmapDao, rb: RabbitMQInstance?) {
+    val allAuthors = (map.collaborators.values + map.uploader).reversed()
+    val authorIds = allAuthors.map { it.id }
+
     val recipients = Follows.selectAll().where {
-        Follows.userId eq map.uploaderId and Follows.upload and Follows.following
+        (Follows.userId inList authorIds) and (Follows.followerId notInList authorIds) and (((Follows.userId eq map.uploaderId) and Follows.upload) or ((Follows.userId neq map.uploaderId) and Follows.collab)) and Follows.following
     }.map { row ->
         row[Follows.followerId].value
     }
 
+    val authorNames = allAuthors.map {
+            "@" + it.uniqueName
+        }.joinToString(separator = ", ")
+
     val (title, adjective) = if (map.lastPublishedAt == null) ("New Map Release" to "released") else ("Map Updated" to "updated")
     Alert.insert(
         title,
-        "@${map.uploader.uniqueName} just $adjective #${toHexString(map.id.value)}: **${map.name}**.\n" +
+        "$authorNames just $adjective #${toHexString(map.id.value)}: **${map.name}**.\n" +
             "*\"${map.description.replace(Regex("\n+"), " ").take(100)}...\"*",
         EAlertType.MapRelease,
         recipients

--- a/src/jvmMain/kotlin/io/beatmaps/util/versions.kt
+++ b/src/jvmMain/kotlin/io/beatmaps/util/versions.kt
@@ -139,8 +139,8 @@ fun pushAlerts(map: BeatmapDao, rb: RabbitMQInstance?) {
     }
 
     val authorNames = allAuthors.map {
-            "@" + it.uniqueName
-        }.joinToString(separator = ", ")
+        "@" + it.uniqueName
+    }.joinToString(separator = ", ")
 
     val (title, adjective) = if (map.lastPublishedAt == null) ("New Map Release" to "released") else ("Map Updated" to "updated")
     Alert.insert(


### PR DESCRIPTION
Two fixes bundled in one:
- The "Notify followers" option will be **off by default** when updating a map that has previously been published, so as to avoid spamming users when a mapper updates a map several times in quick succession without unchecking the option. It remains on by default when it's the first time publishing the map, and in both cases the mapper can change it.
- I had not accounted for the fact that a collaboration could be accepted before a map was published. Now the "collaborated with" alert will only be sent if the collaboration is accepted **when the map is public**. Otherwise, whenever a map is published (including on updates), the alert will be sent to all followers of all mappers involved in the collaboration, following their individual follow preferences. I also added all mapper names to the collaboration text, so that users won't receive alerts for mappers they don't follow publishing maps (instead, it will show a list with all the mappers, which will include at least one that they follow).

I have extensively tested (and debugged) this. It actually took quite a bit of work to make this all work properly, but I'm quite confident now. Feel free to ask me about specific tests that you may think would be necessary and I can confirm to you whether I tried that.