### PR TITLE
Make map embeds lazy load

### DIFF
--- a/src/jsMain/kotlin/io/beatmaps/shared/map/bsr.kt
+++ b/src/jsMain/kotlin/io/beatmaps/shared/map/bsr.kt
@@ -38,6 +38,7 @@ val copyEmbed = fc<CopyBSProps> { props ->
             <iframe 
                 src="${window.location.origin}/maps/${props.map.id}/embed" 
                 width="600" height="145" 
+                loading="lazy"
                 style="border: none; border-radius: 4px;"></iframe>
         """.trimIndent()
 


### PR DESCRIPTION
Fixes certain embeds randomly not loading when many are used on the same page. Thanks to @TheCzar1994.