### PR TITLE
Add text-end to the map's infotable

### DIFF
--- a/src/jsMain/kotlin/io/beatmaps/maps/infotable.kt
+++ b/src/jsMain/kotlin/io/beatmaps/maps/infotable.kt
@@ -122,7 +122,7 @@ val infoTable = fc<InfoTableProps> { props ->
     div("list-group" + if (props.horizontal == true) " list-group-horizontal row m-4" else "") {
         div(itemClasses) {
             +(if (props.map.collaborators?.size != 0) "Mappers" else "Mapper")
-            span("ms-4 text-wrap") {
+            span("ms-4 text-wrap text-end") {
                 uploader {
                     attrs.map = props.map
                 }


### PR DESCRIPTION
Extremely minor but this has always bugged me. Feel free to ignore/close this PR if you intended to have it the way it was or don't feel like making this change...
This should make the Mappers field align to the end of the row when the text wraps versus being the only field that goes to the left.
Before:
<img width="314" alt="before" src="https://github.com/user-attachments/assets/f34e4705-ed1d-477a-b6bc-737afb888d09">
After:
<img width="313" alt="after" src="https://github.com/user-attachments/assets/01a87ce3-5f24-415d-9679-d2d0d291c263">