### PR TITLE
Use fas fa-exclamation instead of fab fa-twitch for Copy BSR

### DIFF
--- a/modules/shared/src/jsMain/kotlin/io/beatmaps/shared/map/bsr.kt
+++ b/modules/shared/src/jsMain/kotlin/io/beatmaps/shared/map/bsr.kt
@@ -30,7 +30,7 @@ val copyBsr = fcmemo<CopyBSProps>("copyBsr") { props ->
             +text
         }
         i {
-            className = ClassName("fab fa-twitch text-info")
+            className = ClassName("fas fa-exclamation text-info")
             ariaHidden = true
         }
     }


### PR DESCRIPTION
As suggested in site-suggestions in BeatSaver Discord
<img width="977" height="238" alt="image" src="https://github.com/user-attachments/assets/104919ff-5291-4624-8d73-d459a27b37e9" />
<img width="1972" height="457" alt="image" src="https://github.com/user-attachments/assets/0ccf810e-eb7c-4ee1-9ab3-810629b3a2ee" />
